### PR TITLE
Fixes an issue with write timeouts on sends that require a receipt or are in a transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -79,8 +79,7 @@ func (tx *Transaction) Send(destination, contentType string, body []byte, opts .
 	}
 
 	f.Header.Set(frame.Transaction, tx.id)
-	tx.conn.sendFrame(f)
-	return nil
+	return tx.conn.sendFrame(f)
 }
 
 // Ack sends an acknowledgement for the message to the server. The STOMP


### PR DESCRIPTION
Fixes an issue with write timeouts on sends that require a receipt or are in a transaction.

Also fixes an issue where errors are not returned correctly from transactional sends upon commit.