### PR TITLE
I had some problems with one of my subscribers hanging for ever. Afte…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -70,7 +70,7 @@ func Connect(conn io.ReadWriteCloser, opts ...func(*Conn) error) (*Conn, error) 
 	c := &Conn{
 		conn:    conn,
 		readCh:  make(chan *frame.Frame, 8),
-		writeCh: make(chan writeRequest, 8),
+		writeCh: make(chan writeRequest, 1000),
 	}
 
 	options, err := newConnOptions(c, opts)


### PR DESCRIPTION
…r tedious investigation I found out that when acking the message - we do it manually - it get stuck on [the line where it is written to the write channel](https://github.com/go-stomp/stomp/blob/master/conn.go#L492). I discovered that the capacity of this channel is just 8. When increasing it to 1000 it all works fine. I processed some 300000 messages with this capacity without a problem.