### PR TITLE
Ensure UNSUBSCRIBE RECEIPTs are handled properly

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/go-stomp/stomp/frame"
@@ -542,12 +541,11 @@ func (c *Conn) Subscribe(destination string, ack AckMode, opts ...func(*frame.Fr
 	}
 
 	sub := &Subscription{
-		id:             id,
-		destination:    destination,
-		conn:           c,
-		ackMode:        ack,
-		C:              make(chan *Message, 16),
-		completedMutex: &sync.Mutex{},
+		id:          id,
+		destination: destination,
+		conn:        c,
+		ackMode:     ack,
+		C:           make(chan *Message, 16),
 	}
 	go sub.readLoop(ch)
 

--- a/subscribe_options.go
+++ b/subscribe_options.go
@@ -32,7 +32,7 @@ func init() {
 	SubscribeOpt.Header = func(key, value string) func(*frame.Frame) error {
 		return func(f *frame.Frame) error {
 			if f.Command != frame.SUBSCRIBE &&
-			   f.Command != frame.UNSUBSCRIBE {
+				f.Command != frame.UNSUBSCRIBE {
 				return ErrInvalidCommand
 			}
 			f.Header.Add(key, value)


### PR DESCRIPTION
Not sure if this repo is still active, but thought I'd offer this up since it bit me. Had a lot of trouble with a relatively simple toy program that basically did the following:

* connect
* produce one message
* subscribe
* consume the message
* unsubscribe
* disconnect

Usually manifested as goroutines stuck waiting for messages that never came, or channel write panics/errors. 

Root cause seems to be a few subtle issues & around `Subscription.Unsubscribe`: the call to sendFrame() does not wait for the implicit RECEIPT triggered by the "receipt" header injected on the connection's processLoop goroutine. As a result, we try to close the channel before the RECEIPT has been processed. Then on top of that, even if the RECEIPT does somehow manage to sneak through, `Subscribe.readLoop` also neglects to handle the RECEIPT & sits on the channel waiting for messages that never come. See the detailed comment in `Subscription.Unsubscribe` for some more detail.

The locking around `s.completed` also looked a bit suspect, so I swapped out the explicit mutex locking & unguarded reads of s.completed with stricter use of atomic reads & writes on a new `s.state` var.

Anyway: unable to check if tests look good with these changes due to what looks like build issues, but anecdotally things got a lot more stable and predictable once these changes were applied.

N.B. this change will slow down calls to Unsubscribe because we block until the RECEIPT is received.