### PR TITLE
Revert "Ensure UNSUBSCRIBE RECEIPTs are handled properly"

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-stomp/stomp/frame"
@@ -541,11 +542,12 @@ func (c *Conn) Subscribe(destination string, ack AckMode, opts ...func(*frame.Fr
 	}
 
 	sub := &Subscription{
-		id:          id,
-		destination: destination,
-		conn:        c,
-		ackMode:     ack,
-		C:           make(chan *Message, 16),
+		id:             id,
+		destination:    destination,
+		conn:           c,
+		ackMode:        ack,
+		C:              make(chan *Message, 16),
+		completedMutex: &sync.Mutex{},
 	}
 	go sub.readLoop(ch)
 

--- a/subscribe_options.go
+++ b/subscribe_options.go
@@ -32,7 +32,7 @@ func init() {
 	SubscribeOpt.Header = func(key, value string) func(*frame.Frame) error {
 		return func(f *frame.Frame) error {
 			if f.Command != frame.SUBSCRIBE &&
-				f.Command != frame.UNSUBSCRIBE {
+			   f.Command != frame.UNSUBSCRIBE {
 				return ErrInvalidCommand
 			}
 			f.Header.Add(key, value)

--- a/subscription.go
+++ b/subscription.go
@@ -3,15 +3,9 @@ package stomp
 import (
 	"fmt"
 	"log"
-	"sync/atomic"
+	"sync"
 
 	"github.com/go-stomp/stomp/frame"
-)
-
-const (
-	subStateActive  = 0
-	subStateClosing = 1
-	subStateClosed  = 2
 )
 
 // The Subscription type represents a client subscription to
@@ -19,12 +13,13 @@ const (
 //
 // Once a client has subscribed, it can receive messages from the C channel.
 type Subscription struct {
-	C           chan *Message
-	id          string
-	destination string
-	conn        *Conn
-	ackMode     AckMode
-	state       int32
+	C              chan *Message
+	id             string
+	destination    string
+	conn           *Conn
+	ackMode        AckMode
+	completed      bool
+	completedMutex *sync.Mutex
 }
 
 // BUG(jpj): If the client does not read messages from the Subscription.C
@@ -51,16 +46,14 @@ func (s *Subscription) AckMode() AckMode {
 // Active returns whether the subscription is still active.
 // Returns false if the subscription has been unsubscribed.
 func (s *Subscription) Active() bool {
-	return atomic.LoadInt32(&s.state) == subStateActive
+	return !s.completed
 }
 
 // Unsubscribes and closes the channel C.
 func (s *Subscription) Unsubscribe(opts ...func(*frame.Frame) error) error {
-	// transition to the "closing" state
-	if !atomic.CompareAndSwapInt32(&s.state, subStateActive, subStateClosing) {
+	if s.completed {
 		return ErrCompletedSubscription
 	}
-
 	f := frame.New(frame.UNSUBSCRIBE, frame.Id, s.id)
 
 	for _, opt := range opts {
@@ -74,30 +67,12 @@ func (s *Subscription) Unsubscribe(opts ...func(*frame.Frame) error) error {
 	}
 
 	s.conn.sendFrame(f)
-
-	// UNSUBSCRIBE is a bit weird in that it is tagged with a "receipt" header
-	// on the I/O goroutine, so the above call to sendFrame() will not wait
-	// for the resulting RECEIPT. We handle the RECEIPT frame triggered by the
-	// implicit header below, with some fancy footwork for things like ERROR
-	// frames & any straggler MESSAGE frames.
-	//
-	// ERROR and RECEIPT are terminal messages: by the time we call close()
-	// on the channel there should be no pending messages on the channel.
-	for {
-		msg := <-s.C
-		// ignore MESSAGEs, bail on ERROR or RECEIPT
-		if msg.Err != nil {
-			msgErr, ok := msg.Err.(*Error)
-			if !ok || msgErr.Frame == nil || msgErr.Frame.Command != frame.RECEIPT {
-				log.Printf("Subscription %s: %s: expected RECEIPT, but got error: %s\n", s.id, s.destination, msg.Err.Error())
-			}
-			break
-		}
+	s.completedMutex.Lock()
+	if !s.completed {
+		s.completed = true
+		close(s.C)
 	}
-
-	// transition to the "closed" state
-	atomic.StoreInt32(&s.state, subStateClosed)
-	close(s.C)
+	s.completedMutex.Unlock()
 	return nil
 }
 
@@ -105,7 +80,7 @@ func (s *Subscription) Unsubscribe(opts ...func(*frame.Frame) error) error {
 // method: many callers will prefer to read from the channel C
 // directly.
 func (s *Subscription) Read() (*Message, error) {
-	if !s.Active() {
+	if s.completed {
 		return nil, ErrCompletedSubscription
 	}
 	msg, ok := <-s.C
@@ -120,17 +95,12 @@ func (s *Subscription) Read() (*Message, error) {
 
 func (s *Subscription) readLoop(ch chan *frame.Frame) {
 	for {
+		if s.completed {
+			return
+		}
+
 		f, ok := <-ch
 		if !ok {
-			state := atomic.LoadInt32(&s.state)
-			if state == subStateActive || state == subStateClosing {
-				msg := &Message{
-					Err: &Error{
-						Message: fmt.Sprintf("Subscription %s: %s: channel read failed", s.id, s.destination),
-					},
-				}
-				s.C <- msg
-			}
 			return
 		}
 
@@ -145,9 +115,11 @@ func (s *Subscription) readLoop(ch chan *frame.Frame) {
 				Header:       f.Header,
 				Body:         f.Body,
 			}
-			if s.Active() {
+			s.completedMutex.Lock()
+			if !s.completed {
 				s.C <- msg
 			}
+			s.completedMutex.Unlock()
 		} else if f.Command == frame.ERROR {
 			message, _ := f.Header.Contains(frame.Message)
 			text := fmt.Sprintf("Subscription %s: %s: ERROR message:%s",
@@ -167,25 +139,14 @@ func (s *Subscription) readLoop(ch chan *frame.Frame) {
 				Header:       f.Header,
 				Body:         f.Body,
 			}
-			state := atomic.LoadInt32(&s.state)
-			if state == subStateActive || state == subStateClosing {
+			s.completedMutex.Lock()
+			if !s.completed {
+				s.completed = true
 				s.C <- msg
+				close(s.C)
 			}
+			s.completedMutex.Unlock()
 			return
-		} else if f.Command == frame.RECEIPT {
-			msg := &Message{
-				Err: &Error{
-					Message: "Unsubscribed",
-					Frame:   f,
-				},
-			}
-			state := atomic.LoadInt32(&s.state)
-			if state == subStateActive || state == subStateClosing {
-				s.C <- msg
-			}
-			return
-		} else {
-			log.Printf("Subscription %s: %s: unsupported frame type: %+v\n", s.id, s.destination, f)
 		}
 	}
 }


### PR DESCRIPTION
Reverts go-stomp/stomp#37, due to failed tests