### PR TITLE
Ensure UNSUBSCRIBE RECEIPTs are handled properly (redux)

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -541,13 +541,15 @@ func (c *Conn) Subscribe(destination string, ack AckMode, opts ...func(*frame.Fr
 		C:     ch,
 	}
 
+	closeMutex := &sync.Mutex{}
 	sub := &Subscription{
-		id:             id,
-		destination:    destination,
-		conn:           c,
-		ackMode:        ack,
-		C:              make(chan *Message, 16),
-		completedMutex: &sync.Mutex{},
+		id:          id,
+		destination: destination,
+		conn:        c,
+		ackMode:     ack,
+		C:           make(chan *Message, 16),
+		closeMutex:  closeMutex,
+		closeCond:   sync.NewCond(closeMutex),
 	}
 	go sub.readLoop(ch)
 

--- a/subscribe_options.go
+++ b/subscribe_options.go
@@ -32,7 +32,7 @@ func init() {
 	SubscribeOpt.Header = func(key, value string) func(*frame.Frame) error {
 		return func(f *frame.Frame) error {
 			if f.Command != frame.SUBSCRIBE &&
-			   f.Command != frame.UNSUBSCRIBE {
+				f.Command != frame.UNSUBSCRIBE {
 				return ErrInvalidCommand
 			}
 			f.Header.Add(key, value)


### PR DESCRIPTION
@worg this is the follow-up RE: #37, sorry about that. Tests pass for me with these changes.

Two changes to my original approach:

* Move the call to `close(s.C)` back to the `Subscription.readLoop` goroutine. Not sure what I was thinking moving that into Unsubscribe.
* Avoid reading from `s.C` in `Subscription.Unsubscribe` while waiting for the RECEIPT to avoid interfering with consumers that might be interested in ERROR frames: instead use a sync.Cond to wait for the transition to `subStateClosed`.