### PR TITLE
set send frame details earlier

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -445,6 +445,10 @@ func createSendFrame(destination, contentType string, body []byte, opts []func(*
 	// an opportunity to remove content-length.
 	f := frame.New(frame.SEND, frame.ContentLength, strconv.Itoa(len(body)))
 	f.Body = body
+	f.Header.Set(frame.Destination, destination)
+	if contentType != "" {
+		f.Header.Set(frame.ContentType, contentType)
+	}
 
 	for _, opt := range opts {
 		if opt == nil {
@@ -453,12 +457,6 @@ func createSendFrame(destination, contentType string, body []byte, opts []func(*
 		if err := opt(f); err != nil {
 			return nil, err
 		}
-	}
-
-	f.Header.Set(frame.Destination, destination)
-
-	if contentType != "" {
-		f.Header.Set(frame.ContentType, contentType)
 	}
 
 	return f, nil


### PR DESCRIPTION
I have a frame option function that keeps track of retries on a message. At a certain count, I wish to push the message off to another destination for later investigation.

Right now, the destination header is set _after_ option functions are called, so you can't change the destination (or even check what the destination will be). Setting the headers earlier solves that issue, but there may be ramifications I don't fully understand.