### PR TITLE
Allow for error handling during Begin

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -578,7 +578,7 @@ func (c *Conn) Ack(m *Message) error {
 	}
 
 	if f != nil {
-		c.sendFrame(f)
+		return c.sendFrame(f)
 	}
 	return nil
 }
@@ -593,7 +593,7 @@ func (c *Conn) Nack(m *Message) error {
 	}
 
 	if f != nil {
-		c.sendFrame(f)
+		return c.sendFrame(f)
 	}
 	return nil
 }
@@ -602,10 +602,17 @@ func (c *Conn) Nack(m *Message) error {
 // and acknowledging. Any messages sent or acknowledged during a transaction
 // will be processed atomically by the STOMP server based on the transaction.
 func (c *Conn) Begin() *Transaction {
+	t, _ := c.BeginWithError()
+	return t
+}
+
+// BeginWithError is used to start a transaction, but also returns the error
+// (if any) from sending the frame to start the transaction.
+func (c *Conn) BeginWithError() (*Transaction, error) {
 	id := allocateId()
 	f := frame.New(frame.BEGIN, frame.Transaction, id)
-	c.sendFrame(f)
-	return &Transaction{id: id, conn: c}
+	err := c.sendFrame(f)
+	return &Transaction{id: id, conn: c}, err
 }
 
 // Create an ACK or NACK frame. Complicated by version incompatibilities.


### PR DESCRIPTION
When calling `.Begin()` on a connection it is desirable to handle errors such that if sending the frame fails because of a connection error (or similar) it can be handled prior to actually sending from within the `Transaction`

This PR adds a new `BeginWithError` function that returns the `Transaction` as well as the `error` from the `.sendFrame` call.  (I'm open to a better name)

It also returns the `.sendFrame` result for `.Ack` and `.Nack` such that you can handle errors there as well.

CC @worg 