### PR TITLE
Ensure the closeMutex is used in sendFrame

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -473,8 +473,10 @@ func createSendFrame(destination, contentType string, body []byte, opts []func(*
 }
 
 func (c *Conn) sendFrame(f *frame.Frame) error {
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
 	if c.closed {
-		defer c.conn.Close()
+		c.conn.Close()
 		return ErrClosedUnexpectedly
 	}
 


### PR DESCRIPTION
We recently enabled `-race` in our `go test` invocation and a project using go-stomp began to report data races.  See below for a full example of the data race output.

The data race warning is correct because `sendFrame` doesn't gate the read access of `c.closed` via `c.closeMutex`.

This PR adds the mutex lock/unlock to `sendFrame`.

-----

```
WARNING: DATA RACE
Read at 0x00c000118660 by goroutine 26:
  github.com/go-stomp/stomp.(*Conn).sendFrame()
      /Users/eborgstrom/go/pkg/mod/github.com/go-stomp/stomp@v2.0.2-0.20181110012836-7ed7cfe401c1+incompatible/conn.go:476 +0x69
  github.com/go-stomp/stomp.(*Conn).BeginWithError()
      /Users/eborgstrom/go/pkg/mod/github.com/go-stomp/stomp@v2.0.2-0.20181110012836-7ed7cfe401c1+incompatible/conn.go:614 +0xc9
  github.com/NerdWallet/yak/go/yak.NewTransaction()
      /Users/eborgstrom/Projects/yak/go/yak/transaction.go:42 +0x19a
  github.com/NerdWallet/yak/go/yak.(*Publisher).Send()
      /Users/eborgstrom/Projects/yak/go/yak/publisher.go:43 +0x284
  github.com/NerdWallet/yak/go/yak.TestConnForBroker.func2()
      /Users/eborgstrom/Projects/yak/go/yak/broker_test.go:320 +0x367
  github.com/NerdWallet/yak/go/yak.brokerTest.func1()
      /Users/eborgstrom/Projects/yak/go/yak/broker_test.go:167 +0x1ba
  testing.tRunner()
      /usr/local/opt/go/libexec/src/testing/testing.go:827 +0x162

Previous write at 0x00c000118660 by goroutine 33:
  github.com/go-stomp/stomp.(*Conn).MustDisconnect()
      /Users/eborgstrom/go/pkg/mod/github.com/go-stomp/stomp@v2.0.2-0.20181110012836-7ed7cfe401c1+incompatible/conn.go:407 +0x10d
  github.com/go-stomp/stomp.processLoop()
      /Users/eborgstrom/go/pkg/mod/github.com/go-stomp/stomp@v2.0.2-0.20181110012836-7ed7cfe401c1+incompatible/conn.go:272 +0xa60

Goroutine 26 (running) created at:
  testing.(*T).Run()
      /usr/local/opt/go/libexec/src/testing/testing.go:878 +0x650
  github.com/NerdWallet/yak/go/yak.TestConnForBroker()
      /Users/eborgstrom/Projects/yak/go/yak/broker_test.go:294 +0xeea
  testing.tRunner()
      /usr/local/opt/go/libexec/src/testing/testing.go:827 +0x162

Goroutine 33 (finished) created at:
  github.com/go-stomp/stomp.Connect()
      /Users/eborgstrom/go/pkg/mod/github.com/go-stomp/stomp@v2.0.2-0.20181110012836-7ed7cfe401c1+incompatible/conn.go:180 +0xa1f
  github.com/NerdWallet/yak/go/yak.(*BrokerConnManager).ConnForBroker()
      /Users/eborgstrom/Projects/yak/go/yak/broker.go:151 +0x13d1
  github.com/NerdWallet/yak/go/yak.TestConnForBroker.func2()
      /Users/eborgstrom/Projects/yak/go/yak/broker_test.go:299 +0xe3
  github.com/NerdWallet/yak/go/yak.brokerTest.func1()
      /Users/eborgstrom/Projects/yak/go/yak/broker_test.go:167 +0x1ba
  testing.tRunner()
      /usr/local/opt/go/libexec/src/testing/testing.go:827 +0x162
```