### PR TITLE
Optimize frame encodeValue unencodeValue, replace with more efficient version

### DIFF
--- a/frame/encode.go
+++ b/frame/encode.go
@@ -1,27 +1,36 @@
 package frame
 
 import (
+	"bytes"
 	"strings"
 )
 
+var (
+	replacerForEncodeValue = strings.NewReplacer(
+		"\\", "\\\\",
+		"\r", "\\r",
+		"\n", "\\n",
+		":", "\\c",
+	)
+	replacerForUnencodeValue = strings.NewReplacer(
+		"\\r", "\r",
+		"\\n", "\n",
+		"\\c", ":",
+		"\\\\", "\\",
+	)
+)
+
 // Encodes a header value using STOMP value encoding
-// TODO: replace with more efficient version.
 func encodeValue(s string) []byte {
-	s = strings.Replace(s, "\\", "\\\\", -1)
-	s = strings.Replace(s, "\r", "\\r", -1)
-	s = strings.Replace(s, "\n", "\\n", -1)
-	s = strings.Replace(s, ":", "\\c", -1)
-	return []byte(s)
+	var buf bytes.Buffer
+	buf.Grow(len(s))
+	replacerForEncodeValue.WriteString(&buf, s)
+	return buf.Bytes()
 }
 
 // Unencodes a header value using STOMP value encoding
-// TODO: replace with more efficient version.
 // TODO: return error if invalid sequences found (eg "\t")
 func unencodeValue(b []byte) (string, error) {
-	s := string(b)
-	s = strings.Replace(s, "\\r", "\r", -1)
-	s = strings.Replace(s, "\\n", "\n", -1)
-	s = strings.Replace(s, "\\c", ":", -1)
-	s = strings.Replace(s, "\\\\", "\\", -1)
+	s := replacerForUnencodeValue.Replace(string(b))
 	return s, nil
 }


### PR DESCRIPTION
Using strings.Replace multi times in "encodeValue" and "unencodeValue" function is low efficience, strings.NewReplacer is the more efficient version, here is the benchmark result.

```
/*
$ go test -check.v -check.b -check.bmem
PASS: encode_test.go:32: EncodeSuite.BenchmarkEncodeValue       10000000               223 ns/op             112 B/op          1 allocs/op
PASS: encode_test.go:48: EncodeSuite.BenchmarkEncodeValueOld     5000000               504 ns/op             480 B/op          9 allocs/op
PASS: encode_test.go:40: EncodeSuite.BenchmarkUnencodeValue      5000000               357 ns/op             208 B/op          4 allocs/op
PASS: encode_test.go:56: EncodeSuite.BenchmarkUnencodeValueOld   5000000               556 ns/op             448 B/op          9 allocs/op
OK: 4 passed
PASS
*/
func (s *EncodeSuite) BenchmarkEncodeValue(c *C) {
	val := "Contains\r\nNewLine and : colon and \\ backslash"
	c.ResetTimer()
	for i := 0; i < c.N; i++ {
		encodeValue(val)
	}
}

func (s *EncodeSuite) BenchmarkUnencodeValue(c *C) {
	val := []byte(`Contains\r\nNewLine and \c colon and \\ backslash`)
	c.ResetTimer()
	for i := 0; i < c.N; i++ {
		unencodeValue(val)
	}
}

func (s *EncodeSuite) BenchmarkEncodeValueOld(c *C) {
	val := "Contains\r\nNewLine and : colon and \\ backslash"
	c.ResetTimer()
	for i := 0; i < c.N; i++ {
		encodeValueOld(val)
	}
}

func (s *EncodeSuite) BenchmarkUnencodeValueOld(c *C) {
	val := []byte(`Contains\r\nNewLine and \c colon and \\ backslash`)
	c.ResetTimer()
	for i := 0; i < c.N; i++ {
		unencodeValueOld(val)
	}
}

func encodeValueOld(s string) []byte {
	s = strings.Replace(s, "\\", "\\\\", -1)
	s = strings.Replace(s, "\r", "\\r", -1)
	s = strings.Replace(s, "\n", "\\n", -1)
	s = strings.Replace(s, ":", "\\c", -1)
	return []byte(s)
}

func unencodeValueOld(b []byte) (string, error) {
	s := string(b)
	s = strings.Replace(s, "\\r", "\r", -1)
	s = strings.Replace(s, "\\n", "\n", -1)
	s = strings.Replace(s, "\\c", ":", -1)
	s = strings.Replace(s, "\\\\", "\\", -1)
	return s, nil
}
```
