### PR TITLE
Add buffer size option to connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -70,6 +70,9 @@ func Dial(network, addr string, opts ...func(*Conn) error) (*Conn, error) {
 // been created by the program. The opts parameter provides the
 // opportunity to specify STOMP protocol options.
 func Connect(conn io.ReadWriteCloser, opts ...func(*Conn) error) (*Conn, error) {
+	reader := frame.NewReader(conn)
+	writer := frame.NewWriter(conn)
+
 	c := &Conn{
 		conn:       conn,
 		closeMutex: &sync.Mutex{},
@@ -80,19 +83,12 @@ func Connect(conn io.ReadWriteCloser, opts ...func(*Conn) error) (*Conn, error) 
 		return nil, err
 	}
 
-	var reader *frame.Reader
-	var writer *frame.Writer
-
 	if options.ReadBufferSize > 0 {
 		reader = frame.NewReaderSize(conn, options.ReadBufferSize)
-	} else {
-		reader = frame.NewReader(conn)
 	}
 
 	if options.WriteBufferSize > 0 {
 		writer = frame.NewWriterSize(conn, options.ReadBufferSize)
-	} else {
-		writer = frame.NewWriter(conn)
 	}
 
 	readChannelCapacity := 20

--- a/conn.go
+++ b/conn.go
@@ -70,9 +70,6 @@ func Dial(network, addr string, opts ...func(*Conn) error) (*Conn, error) {
 // been created by the program. The opts parameter provides the
 // opportunity to specify STOMP protocol options.
 func Connect(conn io.ReadWriteCloser, opts ...func(*Conn) error) (*Conn, error) {
-	reader := frame.NewReader(conn)
-	writer := frame.NewWriter(conn)
-
 	c := &Conn{
 		conn:       conn,
 		closeMutex: &sync.Mutex{},
@@ -81,6 +78,21 @@ func Connect(conn io.ReadWriteCloser, opts ...func(*Conn) error) (*Conn, error) 
 	options, err := newConnOptions(c, opts)
 	if err != nil {
 		return nil, err
+	}
+
+	var reader *frame.Reader
+	var writer *frame.Writer
+
+	if options.ReadBufferSize > 0 {
+		reader = frame.NewReaderSize(conn, options.ReadBufferSize)
+	} else {
+		reader = frame.NewReader(conn)
+	}
+
+	if options.WriteBufferSize > 0 {
+		writer = frame.NewWriterSize(conn, options.ReadBufferSize)
+	} else {
+		writer = frame.NewWriter(conn)
 	}
 
 	readChannelCapacity := 20

--- a/conn_options.go
+++ b/conn_options.go
@@ -22,6 +22,7 @@ type connOptions struct {
 	AcceptVersions                            []string
 	Header                                    *frame.Header
 	ReadChannelCapacity, WriteChannelCapacity int
+	ReadBufferSize, WriteBufferSize           int
 }
 
 func newConnOptions(conn *Conn, opts []func(*Conn) error) (*connOptions, error) {
@@ -156,6 +157,16 @@ var ConnOpt struct {
 	// same time. A high number may affect memory usage while a too low number may lock the
 	// system up. Default is set to 20.
 	WriteChannelCapacity func(capacity int) func(*Conn) error
+
+	// ReadBufferSize specifies number of bytes that can be used to read the message
+	// A high number may affect memory usage while a too low number may lock the
+	// system up. Default is set to 4096.
+	ReadBufferSize func(size int) func(*Conn) error
+
+	// WriteBufferSize specifies number of bytes that can be used to write the message
+	// A high number may affect memory usage while a too low number may lock the
+	// system up. Default is set to 4096.
+	WriteBufferSize func(size int) func(*Conn) error
 }
 
 func init() {
@@ -241,6 +252,20 @@ func init() {
 	ConnOpt.WriteChannelCapacity = func(capacity int) func(*Conn) error {
 		return func(c *Conn) error {
 			c.options.WriteChannelCapacity = capacity
+			return nil
+		}
+	}
+
+	ConnOpt.ReadBufferSize = func(size int) func(*Conn) error {
+		return func(c *Conn) error {
+			c.options.ReadBufferSize = size
+			return nil
+		}
+	}
+
+	ConnOpt.WriteBufferSize = func(size int) func(*Conn) error {
+		return func(c *Conn) error {
+			c.options.WriteBufferSize = size
 			return nil
 		}
 	}


### PR DESCRIPTION
This change adds buffer size option to stomp connection and provides the opportunity to specify read/write buffer size