### PR TITLE
add ConnOption to get CONNECT response headers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -186,12 +186,9 @@ func Connect(conn io.ReadWriteCloser, opts ...func(*Conn) error) (*Conn, error) 
 
 	c.msgSendTimeout = options.MsgSendTimeout
 
-	// TODO(jpj): make any non-standard headers in the CONNECTED
-	// frame available. This could be implemented as:
-	// (a) a callback function supplied as an option; or
-	// (b) a property of the Conn structure (eg CustomHeaders)
-	// Neither options are particularly elegant, so wait until
-	// there is a real need for this.
+	if options.ResponseHeadersCallback != nil {
+		options.ResponseHeadersCallback(response.Header)
+	}
 
 	go readLoop(c, reader)
 	go processLoop(c, writer)

--- a/conn_options.go
+++ b/conn_options.go
@@ -23,6 +23,7 @@ type connOptions struct {
 	Header                                    *frame.Header
 	ReadChannelCapacity, WriteChannelCapacity int
 	ReadBufferSize, WriteBufferSize           int
+	ResponseHeadersCallback                   func(*frame.Header)
 }
 
 func newConnOptions(conn *Conn, opts []func(*Conn) error) (*connOptions, error) {
@@ -167,6 +168,9 @@ var ConnOpt struct {
 	// A high number may affect memory usage while a too low number may lock the
 	// system up. Default is set to 4096.
 	WriteBufferSize func(size int) func(*Conn) error
+
+	// ResponseHeaders lets you provide a callback function to get the headers from the CONNECT response
+	ResponseHeaders func(func(*frame.Header)) func(*Conn) error
 }
 
 func init() {
@@ -266,6 +270,13 @@ func init() {
 	ConnOpt.WriteBufferSize = func(size int) func(*Conn) error {
 		return func(c *Conn) error {
 			c.options.WriteBufferSize = size
+			return nil
+		}
+	}
+
+	ConnOpt.ResponseHeaders = func(callback func(*frame.Header)) func(*Conn) error {
+		return func(c *Conn) error {
+			c.options.ResponseHeadersCallback = callback
 			return nil
 		}
 	}


### PR DESCRIPTION
This PR adds a callback function to ConnOption that can be used to get the headers from the CONNECT response.

Closes https://github.com/go-stomp/stomp/issues/82