### PR TITLE
Fix/read timeout lock

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -20,7 +20,7 @@ const DefaultHeartBeatError = 5 * time.Second
 const DefaultMsgSendTimeout = 10 * time.Second
 
 // Default receipt timeout in Conn.Send function
-const DefaultRcvReceiptTimeout = 10 * time.Second
+const DefaultRcvReceiptTimeout = 30 * time.Second
 
 // A Conn is a connection to a STOMP server. Create a Conn using either
 // the Dial or Connect function.

--- a/conn.go
+++ b/conn.go
@@ -455,14 +455,14 @@ func (c *Conn) Send(destination, contentType string, body []byte, opts ...func(*
 			C:     make(chan *frame.Frame),
 		}
 
-		sendErr := sendDataToWriteChWithTimeout(c.writeCh, request, c.msgSendTimeout)
-		if sendErr != nil {
-			return sendErr
+		err := sendDataToWriteChWithTimeout(c.writeCh, request, c.msgSendTimeout)
+		if err != nil {
+			return err
 		}
 
-		receiptErr := readReceiptWithTimeout(request, c.rcvReceiptTimeout)
-		if receiptErr != nil {
-			return receiptErr
+		err = readReceiptWithTimeout(request, c.rcvReceiptTimeout)
+		if err != nil {
+			return err
 		}
 	} else {
 		// no receipt required

--- a/conn.go
+++ b/conn.go
@@ -16,10 +16,10 @@ import (
 // to avoid premature disconnections due to network latency.
 const DefaultHeartBeatError = 5 * time.Second
 
-// Default timeout of calling Conn.Send function
+// Default send timeout in Conn.Send function
 const DefaultMsgSendTimeout = 10 * time.Second
 
-// Default timeout of calling Conn.Send function
+// Default receipt timeout in Conn.Send function
 const DefaultRcvReceiptTimeout = 10 * time.Second
 
 // A Conn is a connection to a STOMP server. Create a Conn using either

--- a/conn_options.go
+++ b/conn_options.go
@@ -17,6 +17,7 @@ type connOptions struct {
 	WriteTimeout                              time.Duration
 	HeartBeatError                            time.Duration
 	MsgSendTimeout                            time.Duration
+	RcvReceiptTimeout                         time.Duration
 	HeartBeatGracePeriodMultiplier            float64
 	Login, Passcode                           string
 	AcceptVersions                            []string
@@ -34,6 +35,7 @@ func newConnOptions(conn *Conn, opts []func(*Conn) error) (*connOptions, error) 
 		HeartBeatGracePeriodMultiplier: 1.0,
 		HeartBeatError:                 DefaultHeartBeatError,
 		MsgSendTimeout:                 DefaultMsgSendTimeout,
+		RcvReceiptTimeout:              DefaultRcvReceiptTimeout,
 	}
 
 	// This is a slight of hand, attach the options to the Conn long
@@ -139,6 +141,11 @@ var ConnOpt struct {
 	// Less than or equal to zero means infinite
 	MsgSendTimeout func(msgSendTimeout time.Duration) func(*Conn) error
 
+	// RcvReceiptTimeout is a connect option that allows the client to specify
+	// how long to wait for a receipt in the Conn.Send function. This helps
+	// avoid deadlocks. If this is not specified, the default is 10 seconds.
+	RcvReceiptTimeout func(rcvReceiptTimeout time.Duration) func(*Conn) error
+
 	// HeartBeatGracePeriodMultiplier is used to calculate the effective read heart-beat timeout
 	// the broker will enforce for each client’s connection. The multiplier is applied to
 	// the read-timeout interval the client specifies in its CONNECT frame
@@ -224,6 +231,13 @@ func init() {
 	ConnOpt.MsgSendTimeout = func(msgSendTimeout time.Duration) func(*Conn) error {
 		return func(c *Conn) error {
 			c.options.MsgSendTimeout = msgSendTimeout
+			return nil
+		}
+	}
+
+	ConnOpt.RcvReceiptTimeout = func(rcvReceiptTimeout time.Duration) func(*Conn) error {
+		return func(c *Conn) error {
+			c.options.RcvReceiptTimeout = rcvReceiptTimeout
 			return nil
 		}
 	}

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,7 @@ var (
 	ErrClosedUnexpectedly    = newErrorMessage("connection closed unexpectedly")
 	ErrAlreadyClosed         = newErrorMessage("connection already closed")
 	ErrMsgSendTimeout        = newErrorMessage("msg send timeout")
+	ErrMsgReceiptTimeout     = newErrorMessage("msg receipt timeout")
 	ErrNilOption             = newErrorMessage("nil option")
 )
 


### PR DESCRIPTION
We discovered an issue in the library, when Amazon upgraded one of our ActiveMQ instances, which caused execution to get blocked in the `Send()` function. 

It appears this is because the `Send()` function locks the `closeMutex`, sends a message and then attempts to read a receipt from the queue. This is when the upgrade from Amazon then happened, so without a timeout, Line457 in `conn.go` waits forever and means the application needs to be restarted. The functions `Disconnect()` and `MustDisconnect()`cannot run because they are unable to get a lock on the `closeMutex`.

This PR attempts to resolve this issue by adding a timeout when reading the receipt and defaulting this to 30 seconds. 