### PR TITLE
Increase readTimeout tolerance according to RFC

### DIFF
--- a/server/client/conn.go
+++ b/server/client/conn.go
@@ -122,7 +122,7 @@ func (c *Conn) readLoop() {
 			// infinite timeout
 			c.rw.SetReadDeadline(time.Time{})
 		} else {
-			c.rw.SetReadDeadline(time.Now().Add(readTimeout))
+			c.rw.SetReadDeadline(time.Now().Add(readTimeout * 2))
 		}
 		f, err := reader.Read()
 		if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/go-stomp/stomp"
 	. "gopkg.in/check.v1"
@@ -43,6 +44,37 @@ func (s *ServerSuite) TestConnectAndDisconnect(c *C) {
 	c.Assert(err, IsNil)
 
 	conn.Close()
+}
+
+
+func (s *ServerSuite) TestHeartBeatingTolerance(c *C) {
+	// Heart beat should not close connection exactly after not receiving message after cx
+	//  it should add a pretty decent amount of time to counter network delay of other timing issues
+	addr := ":59092"
+	l, err := net.Listen("tcp", addr)
+	c.Assert(err, IsNil)
+	defer func() { l.Close() }()
+	serv := Server{
+		Addr:          "",
+		Authenticator: nil,
+		QueueStorage:  nil,
+		HeartBeat:     5 * time.Millisecond,
+	}
+	go serv.Serve(l)
+
+	conn, err := net.Dial("tcp", "127.0.0.1"+addr)
+	c.Assert(err, IsNil)
+	defer conn.Close()
+
+	client, err := stomp.Connect(conn, stomp.ConnOpt.HeartBeat(5 * time.Millisecond, 5 * time.Millisecond))
+	c.Assert(err, IsNil)
+	defer client.Disconnect()
+
+	time.Sleep(serv.HeartBeat * 50) // let it go for some time to allow client and server to exchange some heart beat
+
+	// Ensure the server has not closed his readChannel
+	err = client.Send("/topic/whatever", "text/plain", []byte("hello"))
+	c.Assert(err, IsNil)
 }
 
 func (s *ServerSuite) TestSendToQueuesAndTopics(c *C) {


### PR DESCRIPTION
About Heart Beating, [RFC](https://stomp.github.io/stomp-specification-1.2.html#Heart-beating) states that:
 > because of timing inaccuracies, the receiver SHOULD be tolerant and take into account an error margin

Most of the client library sends an heart beat when the *cx* delay has been elapsed without sending message. Since the server wait for at max *cx* time it happens that most of the time the client is disconnected before the heart beat actually reach the server.

Multiplying the time by two is a simple way to be more tolerant.
