### PR TITLE
Setup go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features:
 ## Usage Instructions
 
 ```
-go get github.com/go-stomp/stomp
+go get github.com/go-stomp/stomp/v2
 ```
 
 For API documentation, see https://pkg.go.dev/github.com/go-stomp/stomp/v2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 go get github.com/go-stomp/stomp
 ```
 
-For API documentation, see http://godoc.org/github.com/go-stomp/stomp
+For API documentation, see http://godoc.org/github.com/go-stomp/stomp/v2
 
 ## Previous Version
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 go get github.com/go-stomp/stomp
 ```
 
-For API documentation, see http://godoc.org/github.com/go-stomp/stomp/v2
+For API documentation, see https://pkg.go.dev/github.com/go-stomp/stomp/v2
 
 ## Previous Version
 

--- a/ack.go
+++ b/ack.go
@@ -1,7 +1,7 @@
 package stomp
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // The AckMode type is an enumeration of the acknowledgement modes for a

--- a/breaking_changes.md
+++ b/breaking_changes.md
@@ -46,11 +46,11 @@ package, and the types moved are not needed in normal usage of the `stomp` packa
 Version 2 of the stomp library makes use of functional options to provide a clean, flexible way
 of specifying options in the following API calls:
 
-* [Dial()](http://godoc.org/github.com/go-stomp/stomp#Dial)
-* [Connect()](http://godoc.org/github.com/go-stomp/stomp#Connect)
-* [Conn.Send()](http://godoc.org/github.com/go-stomp/stomp#Conn.Send)
-* [Transaction.Send()](http://godoc.org/github.com/go-stomp/stomp#Transaction.Send)
-* [Conn.Subscribe()](http://godoc.org/github.com/go-stomp/stomp#Conn.Subscribe)
+* [Dial()](http://pkg.go.dev/github.com/go-stomp/stomp/v2#Dial)
+* [Connect()](http://pkg.go.dev/github.com/go-stomp/stomp#Connect)
+* [Conn.Send()](http://pkg.go.dev/github.com/go-stomp/stomp#Conn.Send)
+* [Transaction.Send()](http://pkg.go.dev/github.com/go-stomp/stomp#Transaction.Send)
+* [Conn.Subscribe()](http://pkg.go.dev/github.com/go-stomp/stomp#Conn.Subscribe)
 
 The idea for this comes from Dave Cheney's very excellent blog post,
 [Functional Options for Friendly APIs](http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis).

--- a/breaking_changes.md
+++ b/breaking_changes.md
@@ -19,7 +19,7 @@ import (
 Version 2:
 ```go
 import (
-    "github.com/go-stomp/stomp"
+    "github.com/go-stomp/stomp/v2"
 )
 ```
 

--- a/conn.go
+++ b/conn.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Default time span to add to read/write heart-beat timeouts

--- a/conn_options.go
+++ b/conn_options.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // ConnOptions is an opaque structure used to collection options

--- a/conn_test.go
+++ b/conn_test.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/go-stomp/stomp/frame"
-	"github.com/go-stomp/stomp/testutil"
+	"github.com/go-stomp/stomp/v2/frame"
+	"github.com/go-stomp/stomp/v2/testutil"
 	. "gopkg.in/check.v1"
 )
 

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,7 @@
 package stomp
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Error values

--- a/example_test.go
+++ b/example_test.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-stomp/stomp"
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 func ExampleConn_Send(c *stomp.Conn) error {

--- a/examples/client_test/main.go
+++ b/examples/client_test/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-stomp/stomp"
+	"github.com/go-stomp/stomp/v2"
 )
 
 const defaultPort = ":61613"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-stomp/stomp
+module github.com/go-stomp/stomp/v2
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/go-stomp/stomp
+
+go 1.11
+
+require gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/message.go
+++ b/message.go
@@ -2,7 +2,7 @@ package stomp
 
 import (
 	"io"
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // A Message represents a message received from the STOMP server.

--- a/send_options.go
+++ b/send_options.go
@@ -1,7 +1,7 @@
 package stomp
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // SendOpt contains options for for the Conn.Send and Transaction.Send functions.

--- a/server/client/conn.go
+++ b/server/client/conn.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-stomp/stomp"
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Maximum number of pending frames allowed to a client.

--- a/server/client/frame.go
+++ b/server/client/frame.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-stomp/stomp"
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 const (

--- a/server/client/frame_test.go
+++ b/server/client/frame_test.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"github.com/go-stomp/stomp"
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2"
+	"github.com/go-stomp/stomp/v2/frame"
 	. "gopkg.in/check.v1"
 )
 

--- a/server/client/request.go
+++ b/server/client/request.go
@@ -3,7 +3,7 @@ package client
 import (
 	"strconv"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Opcode used in client requests.

--- a/server/client/subscription.go
+++ b/server/client/subscription.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 type Subscription struct {

--- a/server/client/tx_store.go
+++ b/server/client/tx_store.go
@@ -3,7 +3,7 @@ package client
 import (
 	"container/list"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 type txStore struct {

--- a/server/client/tx_store_test.go
+++ b/server/client/tx_store_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 	. "gopkg.in/check.v1"
 )
 

--- a/server/processor.go
+++ b/server/processor.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-stomp/stomp/frame"
-	"github.com/go-stomp/stomp/server/client"
-	"github.com/go-stomp/stomp/server/queue"
-	"github.com/go-stomp/stomp/server/topic"
+	"github.com/go-stomp/stomp/v2/frame"
+	"github.com/go-stomp/stomp/v2/server/client"
+	"github.com/go-stomp/stomp/v2/server/queue"
+	"github.com/go-stomp/stomp/v2/server/topic"
 )
 
 type requestProcessor struct {

--- a/server/queue/memory_queue.go
+++ b/server/queue/memory_queue.go
@@ -3,7 +3,7 @@ package queue
 import (
 	"container/list"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // In-memory implementation of the QueueStorage interface.

--- a/server/queue/memory_queue_test.go
+++ b/server/queue/memory_queue_test.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 	. "gopkg.in/check.v1"
 )
 

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -4,8 +4,8 @@ Package queue provides implementations of server-side queues.
 package queue
 
 import (
-	"github.com/go-stomp/stomp/frame"
-	"github.com/go-stomp/stomp/server/client"
+	"github.com/go-stomp/stomp/v2/frame"
+	"github.com/go-stomp/stomp/v2/server/client"
 )
 
 // Queue for storing message frames.

--- a/server/queue/storage.go
+++ b/server/queue/storage.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Interface for queue storage. The intent is that

--- a/server/queue_storage.go
+++ b/server/queue_storage.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // QueueStorage is an interface that abstracts the queue storage mechanism.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-stomp/stomp"
+	"github.com/go-stomp/stomp/v2"
 	. "gopkg.in/check.v1"
 )
 

--- a/server/topic/subscription.go
+++ b/server/topic/subscription.go
@@ -1,7 +1,7 @@
 package topic
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Subscription is the interface that wraps a subscriber to a topic.

--- a/server/topic/topic.go
+++ b/server/topic/topic.go
@@ -6,7 +6,7 @@ package topic
 import (
 	"container/list"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // A Topic is used for broadcasting to subscribed clients.

--- a/server/topic/topic_test.go
+++ b/server/topic/topic_test.go
@@ -1,7 +1,7 @@
 package topic
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 	. "gopkg.in/check.v1"
 )
 

--- a/stomp.go
+++ b/stomp.go
@@ -20,7 +20,7 @@ Disconnect method. This will perform a graceful shutdown sequence as specified i
 
 Source code and other details for the project are available at GitHub:
 
-   https://github.com/go-stomp/stomp
+   https://github.com/go-stomp/stomp/v2
 
 */
 package stomp

--- a/stompd/main.go
+++ b/stompd/main.go
@@ -18,7 +18,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/go-stomp/stomp/server"
+	"github.com/go-stomp/stomp/v2/server"
 )
 
 // TODO: experimenting with ways to gracefully shutdown the server,

--- a/subscribe_options.go
+++ b/subscribe_options.go
@@ -1,7 +1,7 @@
 package stomp
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // SubscribeOpt contains options for for the Conn.Subscribe function.

--- a/subscription.go
+++ b/subscription.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 const (

--- a/transaction.go
+++ b/transaction.go
@@ -1,7 +1,7 @@
 package stomp
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // A Transaction applies to the sending of messages to the STOMP server,

--- a/validator.go
+++ b/validator.go
@@ -1,7 +1,7 @@
 package stomp
 
 import (
-	"github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v2/frame"
 )
 
 // Validator is an interface for validating STOMP frames.

--- a/version_test.go
+++ b/version_test.go
@@ -3,7 +3,7 @@ package stomp_test
 import (
 	"testing"
 
-	"github.com/go-stomp/stomp"
+	"github.com/go-stomp/stomp/v2"
 )
 
 func TestSupportsNack(t *testing.T) {


### PR DESCRIPTION
Add go modules support.

Recommended actions before merging:
 - Remove the v2 branch (as it can conflict with the *go module* resolution)
 - Create a branch named v1 (with head being the last v1 tag)
