### PR TITLE
Fix heart beat problem in server/client/conn.go

### DIFF
--- a/server/client/conn.go
+++ b/server/client/conn.go
@@ -188,11 +188,11 @@ func (c *Conn) processLoop() {
 
 	c.writer = frame.NewWriter(c.rw)
 	c.stateFunc = connecting
-	for {
-		var timerChannel <-chan time.Time
-		var timer *time.Timer
 
-		if c.writeTimeout > 0 {
+	var timerChannel <-chan time.Time
+	var timer *time.Timer
+	for {
+		if c.writeTimeout > 0 && timer == nil {
 			timer = time.NewTimer(c.writeTimeout)
 			timerChannel = timer.C
 		}
@@ -310,6 +310,11 @@ func (c *Conn) processLoop() {
 			}
 
 		case _ = <-timerChannel:
+			// stop the heart-beat timer
+			if timer != nil {
+				timer.Stop()
+				timer = nil
+			}
 			// write a heart-beat
 			err := c.writer.Write(nil)
 			if err != nil {


### PR DESCRIPTION
Whenever the reading loop was reading data it had the side effect of reseting the *writeTimeout* timer used to send heart beat to the client (this was due to variable scope).

And if the there is several message in a row to read i will postpone the heartbeat to much and result in the connection being closed.

Fix #66