### PR TITLE
Reduce encodeValue allocations

### DIFF
--- a/frame/encode.go
+++ b/frame/encode.go
@@ -20,14 +20,6 @@ var (
 	)
 )
 
-// Encodes a header value using STOMP value encoding
-func encodeValue(s string) []byte {
-	var buf bytes.Buffer
-	buf.Grow(len(s))
-	replacerForEncodeValue.WriteString(&buf, s)
-	return buf.Bytes()
-}
-
 // Unencodes a header value using STOMP value encoding
 // TODO: return error if invalid sequences found (eg "\t")
 func unencodeValue(b []byte) (string, error) {

--- a/frame/writer.go
+++ b/frame/writer.go
@@ -53,7 +53,7 @@ func (w *Writer) Write(f *Frame) error {
 			for i := 0; i < f.Header.Len(); i++ {
 				key, value := f.Header.GetAt(i)
 				//println("   ", key, ":", value)
-				_, err = w.writer.Write(encodeValue(key))
+				_, err = replacerForEncodeValue.WriteString(w.writer, key)
 				if err != nil {
 					return err
 				}
@@ -61,7 +61,7 @@ func (w *Writer) Write(f *Frame) error {
 				if err != nil {
 					return err
 				}
-				_, err = w.writer.Write(encodeValue(value))
+				_, err = replacerForEncodeValue.WriteString(w.writer, value)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Please check! w.writer satisfies both io.Writer and io.StringWriter so no need to use any middleware function to replace symbols.