### PR TITLE
Remove unneeded test

### DIFF
--- a/frame/encode_test.go
+++ b/frame/encode_test.go
@@ -8,11 +8,6 @@ type EncodeSuite struct{}
 
 var _ = Suite(&EncodeSuite{})
 
-func (s *EncodeSuite) TestEncodeValue(c *C) {
-	val := encodeValue("Contains\r\nNewLine and : colon and \\ backslash")
-	c.Check(string(val), Equals, `Contains\r\nNewLine and \c colon and \\ backslash`)
-}
-
 func (s *EncodeSuite) TestUnencodeValue(c *C) {
 	val, err := unencodeValue([]byte(`Contains\r\nNewLine and \c colon and \\ backslash`))
 	c.Check(err, IsNil)


### PR DESCRIPTION
`encodeValue` was removed on #100 but the test for it was kept, this PR removes the failing and now unneeded test