### PR TITLE
fix incorrect header for message id in ACK frames

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -750,10 +750,10 @@ func (c *Conn) createAckNackFrame(msg *Message, ack bool) (*frame.Frame, error) 
 			return nil, missingHeader(frame.MessageId)
 		}
 	case V12:
-		if ack, ok := msg.Header.Contains(frame.Ack); ok {
+		if ack, ok := msg.Header.Contains(frame.Id); ok {
 			f.Header.Add(frame.Id, ack)
 		} else {
-			return nil, missingHeader(frame.Ack)
+			return nil, missingHeader(frame.Id)
 		}
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -354,7 +354,7 @@ func subscribeHelper(c *C, ackMode AckMode, version Version, opts ...func(*frame
 				frame.MessageId, messageId,
 				frame.Destination, destination)
 			if version == V12 {
-				f4.Header.Add(frame.Ack, messageId)
+				f4.Header.Add(frame.Id, messageId)
 			}
 			f4.Body = []byte(bodyText)
 			err = rw.Write(f4)
@@ -461,7 +461,7 @@ func subscribeTransactionHelper(c *C, ackMode AckMode, version Version, abort bo
 				frame.MessageId, messageId,
 				frame.Destination, destination)
 			if version == V12 {
-				f4.Header.Add(frame.Ack, messageId)
+				f4.Header.Add(frame.Id, messageId)
 			}
 			f4.Body = []byte(bodyText)
 			err = rw.Write(f4)

--- a/server/client/conn.go
+++ b/server/client/conn.go
@@ -415,9 +415,9 @@ func (c *Conn) allocateMessageId(f *frame.Frame, sub *Subscription) {
 		// if there is any requirement by the client to acknowledge, set
 		// the ack header as per STOMP 1.2
 		if sub == nil || sub.ack == frame.AckAuto {
-			f.Header.Del(frame.Ack)
+			f.Header.Del(frame.Id)
 		} else {
-			f.Header.Set(frame.Ack, messageId)
+			f.Header.Set(frame.Id, messageId)
 		}
 	}
 }
@@ -659,7 +659,7 @@ func (c *Conn) handleAck(f *frame.Frame) error {
 	var err error
 	var msgId string
 
-	if ack, ok := f.Header.Contains(frame.Ack); ok {
+	if ack, ok := f.Header.Contains(frame.Id); ok {
 		msgId = ack
 	} else if msgId, ok = f.Header.Contains(frame.MessageId); !ok {
 		return missingHeader(frame.MessageId)
@@ -702,7 +702,7 @@ func (c *Conn) handleNack(f *frame.Frame) error {
 	var err error
 	var msgId string
 
-	if ack, ok := f.Header.Contains(frame.Ack); ok {
+	if ack, ok := f.Header.Contains(frame.Id); ok {
 		msgId = ack
 	} else if msgId, ok = f.Header.Contains(frame.MessageId); !ok {
 		return missingHeader(frame.MessageId)


### PR DESCRIPTION
http://stomp.github.io/stomp-specification-1.2.html#ACK

> The ACK frame MUST include an id header matching the ack header of the MESSAGE being acknowledged.

So, instead of "ack" header ACK frame must include "id" header