### PR TITLE
fix subscription channel set twice for replyTo case

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -367,24 +367,32 @@ func processLoop(c *Conn, writer *frame.Writer) {
 
 			switch req.Frame.Command {
 			case frame.SUBSCRIBE:
-				id, _ := req.Frame.Header.Contains(frame.Id)
-				channels[id] = req.C
-
 				// if using a temp queue, map that destination as a known channel
 				// however, don't send the frame, it's most likely an invalid destination
 				// on the broker.
 				if replyTo, ok := req.Frame.Header.Contains(ReplyToHeader); ok {
 					channels[replyTo] = req.C
 					sendFrame = false
+				} else {
+					id, _ := req.Frame.Header.Contains(frame.Id)
+					channels[id] = req.C
 				}
 
 			case frame.UNSUBSCRIBE:
-				id, _ := req.Frame.Header.Contains(frame.Id)
-				// is this trying to be too clever -- add a receipt
-				// header so that when the server responds with a
-				// RECEIPT frame, the corresponding channel will be closed
-				req.Frame.Header.Set(frame.Receipt, id)
-
+				if replyTo, ok := req.Frame.Header.Contains(ReplyToHeader); ok {
+					ch, ok := channels[replyTo]
+					if ok {
+						delete(channels, replyTo)
+						close(ch)
+					}
+					sendFrame = false
+				} else {
+					id, _ := req.Frame.Header.Contains(frame.Id)
+					// is this trying to be too clever -- add a receipt
+					// header so that when the server responds with a
+					// RECEIPT frame, the corresponding channel will be closed
+					req.Frame.Header.Set(frame.Receipt, id)
+				}
 			}
 
 			// frame to send, if enabled
@@ -645,6 +653,12 @@ func (c *Conn) Subscribe(destination string, ack AckMode, opts ...func(*frame.Fr
 		}
 	}
 
+	replyTo, replyToSet := subscribeFrame.Header.Contains(ReplyToHeader)
+
+	if replyToSet {
+		subscribeFrame.Header.Set(frame.Id, replyTo)
+	}
+
 	// If the option functions have not specified the "id" header entry,
 	// create one.
 	id, ok := subscribeFrame.Header.Contains(frame.Id)
@@ -661,6 +675,7 @@ func (c *Conn) Subscribe(destination string, ack AckMode, opts ...func(*frame.Fr
 	closeMutex := &sync.Mutex{}
 	sub := &Subscription{
 		id:          id,
+		replyToSet:  replyToSet,
 		destination: destination,
 		conn:        c,
 		ackMode:     ack,

--- a/subscription.go
+++ b/subscription.go
@@ -21,6 +21,7 @@ const (
 type Subscription struct {
 	C           chan *Message
 	id          string
+	replyToSet  bool
 	destination string
 	conn        *Conn
 	ackMode     AckMode
@@ -73,6 +74,10 @@ func (s *Subscription) Unsubscribe(opts ...func(*frame.Frame) error) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if s.replyToSet {
+		f.Header.Set(ReplyToHeader, s.id)
 	}
 
 	s.conn.sendFrame(f)


### PR DESCRIPTION
For Subscribe, when ReplyTo header is set, the response channel will be set in the channel map twice in function processLoop.
Then if an ERROR frame is received, that response channel will be in the loop twice, the first time it will be closed, the second time will trigger panic for sending to closed channel.

Fix by force id to be equal to ReplyTo header value, and use the same trick to remove it from the channel map.