### PR TITLE
expose a few connection stats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.13.x, 1.x ]
+        go-version: [ 1.15.x, 1.x ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/conn_options.go
+++ b/conn_options.go
@@ -198,6 +198,9 @@ var ConnOpt struct {
 
 	// Logger lets you provide a callback function that sets the logger used by a connection
 	Logger func(logger Logger) func(*Conn) error
+
+	// Enable statistical gathering for reading/writing messages from the server
+	WithStats func() func(*Conn) error
 }
 
 func init() {
@@ -335,6 +338,13 @@ func init() {
 				c.options.Logger = log
 			}
 
+			return nil
+		}
+	}
+
+	ConnOpt.WithStats = func() func(*Conn) error {
+		return func(conn *Conn) error {
+			conn.statsEnabled = true
 			return nil
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -705,7 +705,8 @@ func createHeartBeatConnection(
 
 	conn, err := Connect(fc1,
 		ConnOpt.HeartBeat(time.Millisecond, time.Millisecond),
-		ConnOpt.HeartBeatError(readTimeoutError))
+		ConnOpt.HeartBeatError(readTimeoutError),
+		ConnOpt.WithStats())
 	c.Assert(conn, NotNil)
 	c.Assert(err, IsNil)
 	<-stop

--- a/conn_test.go
+++ b/conn_test.go
@@ -659,6 +659,10 @@ func (s *StompSuite) TestHeartBeatReadTimeout(c *C) {
 	msg, ok = <-sub.C
 	c.Assert(msg, IsNil)
 	c.Assert(ok, Equals, false)
+
+	stats := conn.Stats()
+	c.Assert(stats.WritesSent, Equals, int64(1))
+	c.Assert(stats.ReadsReceived, Equals, int64(1))
 }
 
 func (s *StompSuite) TestHeartBeatWriteTimeout(c *C) {


### PR DESCRIPTION
My company currently uses go-stomp in a sidecar attached to a main service. We've seen some deadlocks during normal operation, and wanted to monitor a few internal states within go-stomp. This change adds a simple struct defining the sizes of the read and write channels in a `Connection` object, as well as a few super basic counters. Our software would periodically call `Connection.Stats()` and export the data to our metrics systems for further monitoring.